### PR TITLE
Add project codex docs and slingshot spec

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,25 @@
+# .codex Overview
+
+This folder is the shared project brain for Ain't Got No Body. It is meant to be skimmed quickly by humans and AI to understand the game and continue work without re-discovery.
+
+## How to Use
+- Start with `map.md` for orientation, then `slingshot_spec.md` for the core mechanic.
+- Record progress and decisions in `journal.md` after every working session.
+- Plan work in `todo.md`; keep item IDs stable.
+- Update specs and plans when you change behavior, assets, or scope.
+
+## File Index
+- `map.md` — repo/scene map and starting points.
+- `slingshot_spec.md` — current-state description of the slingshot mechanic.
+- `prd.md` — product requirements tailored to this project.
+- `design.md` — game loop, level, and narrative guidelines.
+- `tech.md` — architecture, systems, and engineering practices.
+- `todo.md` — prioritized, acceptance-testable backlog.
+- `journal.md` — chronological log of work/decisions/risks.
+- `release_plan.md` — milestones, QA bars, and launch readiness.
+- `known_issues.md` — bugs/tech debt with reproduction notes.
+
+## Conventions
+- Use IDs: `EPIC-###`, `FEAT-###`, `TASK-###`, `BUG-###`, `CHORE-###`.
+- Keep entries concise, with repo paths and scene names where relevant.
+- Maintain a **Known / Unknown** section in relevant docs to highlight facts vs. open questions.

--- a/.codex/design.md
+++ b/.codex/design.md
@@ -1,0 +1,32 @@
+# Design Notes
+
+## Core Loop
+- Launch the skull toward the level exit using slingshot arcs; manage rebounds and conveyors/moving platforms.
+- On reaching the “body” (`body_goal.tscn`), play end dialogue (“not my body”) and continue to the next level/world via `level_end.gd`.
+
+## Stage Loop
+1. Spawn at current checkpoint (`player_checkpoint.tscn`) in a world scene.
+2. Aim/launch, traverse hazards and platforms.
+3. Hit death zones to respawn; reach body goal to trigger dialogue and score UI.
+4. Transition to next world or repeat loop.
+
+## Level Design Principles
+- Keep landing zones visible; avoid blind off-screen arcs. Use camera triggers to frame targets.
+- Teach angles: early ramps with clear surfaces; later add conveyors/moving platforms to influence bounce.
+- Provide recovery: frequent checkpoints, brake-friendly safe zones, death floors instead of soft-lock pits.
+- Surfaces should telegraph bounce vs. stickiness; align TileMap normals to avoid unfair ricochets.
+
+## Narrative Structure
+- Episodic searches for the right body; each stage ends with the reveal it’s wrong.
+- Dialogue resources (`dialogue/intro.dialogue`, `not_my_body.dialogue`) deliver flavor between levels. Expand with escalating absurdity.
+
+## Enemies/Hazards
+- Present: death zones, conveyors, moving platforms, pistons/obstacles (see `scenes/common/world_obstacles`).
+- Philosophy: hazards should be telegraphed; avoid instant off-screen hits. Use sound cues and consistent visuals.
+
+## Economy/Progression
+- Currently none beyond coins/lives counters in HUD; no permanent meta-progression. Keep scores as optional flair unless expanded later.
+
+## Known / Unknown
+- **Known:** Body goal triggers event; checkpoints set respawn; level timer tracked in HUD.
+- **Unknown:** Final world count and unique mechanics for world_2; narrative beats beyond existing dialogue files.

--- a/.codex/journal.md
+++ b/.codex/journal.md
@@ -1,0 +1,12 @@
+# Development Journal
+
+## 2025-02-22
+- Mapped project entry (`project.godot` → `scenes/menus/main_menu.tscn`) and world flow via `scripts/ui/main_menui_control.gd`.
+- Documented player slingshot mechanic from `scripts/movement/player.gd` and trajectory preview in `scripts/gameplay/trajectory_line_rigidbody.gd`.
+- Identified level-end loop through `body_goal.tscn` triggering `level_end` event and UI (`level_end.gd`).
+- Cataloged exports (Web/Windows configured; Linux placeholder) and hazards/checkpoints in `scenes/common/world_obstacles`.
+- Created `.codex` documentation set (map, spec, PRD, design, tech, backlog, release plan, known issues).
+
+**Risks/Unknowns**: Actual gravity value not recorded; SaveManager wiring unclear; camera framing per level unverified; world_2 content needs validation.
+
+**Next Actions**: Measure gravity and sync trajectory preview (TASK-001); playtest world_1 for camera framing and soft-locks (FEAT-004, TASK-004); verify SaveManager flow (TASK-002).

--- a/.codex/known_issues.md
+++ b/.codex/known_issues.md
@@ -1,0 +1,7 @@
+# Known Issues
+
+- BUG-001: Rotation reset uses `move_up` input instead of dedicated `reset_rotation`; may conflict with upward aiming expectations. Re-map and update UI.
+- ISSUE-001: SaveManager autoload present but not confirmed in menu/world flows; risk of nonfunctional save/load.
+- ISSUE-002: Linux export preset lacks path/output configuration in `export_presets.cfg`.
+- ISSUE-003: Trajectory gravity value not explicitly documented; potential mismatch with runtime gravity if settings change.
+- ISSUE-004: Camera framing per level unverified; possible off-screen landings or excessive shake.

--- a/.codex/map.md
+++ b/.codex/map.md
@@ -1,0 +1,26 @@
+# Repository Map
+
+## Start Here
+- **Main entry:** `project.godot` → `run/main_scene` points to `scenes/menus/main_menu.tscn`.
+- **Gameplay flow:** `scenes/menus/main_menu.tscn` (script `scripts/ui/main_menui_control.gd`) loads world scenes from `game_resources/world_refs` (e.g., `world_1.tres`) into `scenes/worlds/world_1.tscn`, which hosts level chunks and the player.
+- **Player:** `scenes/common/player.tscn` (script `scripts/movement/player.gd`) is spawned by `scripts/gameplay/world.gd`.
+
+## Scenes and Scripts
+- **Menus:** `scenes/menus/main_menu.tscn` (UI flow in `scripts/ui/main_menui_control.gd`), background motion via `scripts/ui/skull_launcher.gd`, settings control `scripts/ui/settings_control.gd`.
+- **Worlds:** `scenes/worlds/world_1.tscn`, `world_2.tscn` use `scripts/gameplay/world.gd` to manage player spawn, HUD, dialogue, checkpoints, and level-end events.
+- **Levels:** Level chunks under `scenes/worlds/world_1/level_*.tscn` and `world_2/level_*.tscn` share `scripts/gameplay/level.gd` (sets size, camera trigger setup). Body goal example in `world_1/level_2.tscn` instancing `scenes/common/world_obstacles/body_goal.tscn`.
+- **Player Control:** `scripts/movement/player.gd` (CharacterBody2D). Trajectory preview `scripts/gameplay/trajectory_line_rigidbody.gd`. Variants `player_v_1.gd`, `player_v_2.gd`, `player_v_3.gd`, and `rigid_body_character.gd` exist but are unused by the current world spawner.
+- **Camera:** Phantom Camera plugin. Goal camera scene `scenes/common/camera/goal_cam.tscn` with `scenes/common/camera/goal_cam.gd`; triggers via `scenes/common/camera/2d_camera_trigger.gd` and `camera_trigger_targeter.gd`.
+- **UI:** HUD `scenes/common/ui/player_hud.tscn`, level end `scenes/common/ui/level_end.tscn` (`level_end.gd`), pause `scenes/common/ui/pause_menu.tscn`, load button `scenes/common/ui/load_button.tscn`.
+- **Autoloads:** Defined in `project.godot`: `SoundManager`, `SceneTransitionManager`, `DataManager`, `SaveManager`, `GameManager`, `CameraShakeManager`, `EventBus`, `DialogueManager`, `PhantomCameraManager`.
+- **Dialogue:** Resources under `dialogue/`, panel `dialogue/balloons/dialogue_panel.tscn` used in world intro/end.
+- **Obstacles & Hazards:** `scenes/common/world_obstacles` includes `death_zone.tscn` (`scripts/gameplay/death_zone.gd`), `moving_platform.tscn`, `conveyor.tscn`, `body_goal.tscn` (level completion trigger), `player_checkpoint.tscn`.
+
+## Assets
+- **Art:** Pixel art in `assets/aseprite/` (e.g., skull, background, body sprite) and `sprites/`.
+- **Audio:** Music and SFX under `assets/audio/`; configured via `scripts/preloads/data_manager.gd`.
+- **Shaders:** Post-processing and utility shaders under `shaders/` and `scenes/post_processing`.
+
+## Known / Unknown
+- **Known:** Main scene path, player controller location, level-end is tied to `body_goal.tscn` emitting `level_end` event.
+- **Unknown:** Exact tile layouts per level (TileMap data), camera tuning per level, completeness of world_2 flow and whether additional cutscenes exist. Validate during playtests.

--- a/.codex/prd.md
+++ b/.codex/prd.md
@@ -1,0 +1,46 @@
+# Product Requirements Document
+
+## Vision
+Guide a disembodied skull through side-scrolling stages using only slingshot arcs. Each stage ends with a false “body” reveal, pushing the darkly comic search forward.
+
+## Pillars
+1. **Slingshot Mastery**: Aiming, arc prediction, and bounce control are the core verbs.
+2. **Readability & Fairness**: Clear landing zones, minimal blind leaps, consistent physics.
+3. **Fast Retries**: Immediate respawn/checkpoint, minimal downtime.
+4. **Tone**: Dark humor/absurdity; light dialogue between stages.
+
+## Target Audience & Platforms
+- Audience: Fans of physics-momentum platformers (e.g., Angry Birds trajectory meets platforming).
+- Platforms (assumed): PC (Windows/Linux) and Web export; controller support optional. Marked assumption until validated.
+
+## Scope (MoSCoW)
+- **Must**: Slingshot-only traversal (rotation aim + space to launch), trajectory preview, checkpoints/death reset, level-end body reveal with dialogue, functional HUD/pause, exports for Web/Windows.
+- **Should**: Camera framing that keeps arc and landing visible; consistent bounce surfaces; quick restart option; simple settings (audio toggle, volume).
+- **Could**: Gamepad aim/launch, accessibility assists (slow-mo aim, colorblind-safe hazards), optional collectibles scoring.
+- **Won’t (for now)**: Mid-air steering that alters velocity, RPG-style progression, complex inventory.
+
+## UX Requirements
+- Aiming clarity: trajectory line visible when grounded and aimed; consider angle snapping for onboarding.
+- Landing visibility: camera keeps destination area on screen; avoid off-screen hazards.
+- Feedback: audio/FX on launch, impact, and death; quick fade/restart.
+- Time-to-retry: respawn in <2s; button/menu option to restart level.
+
+## Difficulty Philosophy
+- Skill comes from learning arc timing and bounce behavior. Early levels teach safe angles; later stages add moving platforms, conveyors, and ricochet challenges.
+- Tuning knobs: `jump_force`, `tilt_speed`, `brake_factor`, `bounciness`, gravity, hazard spacing, checkpoint density.
+
+## Accessibility
+- Visual clarity: high-contrast landing zones; limit screen shake (Phantom Camera noise) or provide toggle.
+- Input: allow remapping; deadzone/aim-sensitivity tuning for controllers if added.
+- Comfort: option to reduce motion blur/shake; provide color-safe hazard indicators.
+
+## Acceptance Criteria (Musts)
+- Player can aim/launch with current controls; trajectory preview matches applied arc within tolerance.
+- Death zones reset player at last checkpoint; lives decrement displayed.
+- Body goal triggers end dialogue and transitions to level-end UI with continue option.
+- Exports build on Web and Windows without missing dependencies.
+
+## Release Criteria / DoD
+- All P0/P1 items in `todo.md` closed; no known crash-on-boot; level-end loop works across all shipped levels.
+- Stable FPS on target hardware (60fps on PC/Web in test scenes); no soft-locks without recovery.
+- Basic accessibility options present or explicitly deferred with TODO.

--- a/.codex/release_plan.md
+++ b/.codex/release_plan.md
@@ -1,0 +1,32 @@
+# Release Plan
+
+## Milestones
+1. **Prototype Stabilization (P0)**: Polish slingshot feel (FEAT-001), fast retry loop (FEAT-002), level-end loop (FEAT-003).
+2. **Content Complete (P1)**: Camera/readability (FEAT-004), settings/accessibility (FEAT-005), level content review (TASK-003), soft-lock fixes (TASK-004).
+3. **Beta**: Export readiness (FEAT-006); integrate save/settings decisions (TASK-002); performance profiling on target platforms.
+4. **RC**: Full playthrough of all worlds; bug triage to BUG/CHORE list; finalize store assets (capsule/screenshot/trailer tasks TBD).
+5. **Release**: Ship Web and Windows builds; post-launch hotfix window for crash/soft-lock fixes.
+
+## Bug Bar & Performance Targets
+- No P0/P1 open issues; no crashes on boot/start/level transition.
+- 60 FPS target on PC/Web in world_1 scenes; load times <5s on Web.
+- No known soft-locks; death/reset always available.
+
+## QA Matrix (Smoke)
+- Boot main menu, start world_1, reach checkpoint, die and respawn.
+- Launch arcs across conveyors/moving platforms; trajectory preview matches outcome.
+- Reach body goal, play dialogue, view level-end UI, continue to next level/world.
+- Pause/resume and settings adjustments do not break audio/state.
+- Exports (Web/Windows/Linux) launch and input works (keyboard at minimum).
+
+## Store Requirements (Assumed Steam-ready)
+- Capsule art (portrait & landscape), 5+ screenshots, short trailer showing slingshot + body reveal loop.
+- Text: description, feature bullets, controls, accessibility notes.
+
+## Post-Launch
+- Week 1 hotfix scope: crash fixes, soft-lock fixes, major camera/readability adjustments based on feedback.
+- Collect telemetry manually via feedback form until analytics strategy decided (assumption).
+
+## Known / Unknown
+- **Known:** Export presets exist for Web/Windows; Linux preset missing path; dialogues in place for intro/end.
+- **Unknown:** Final store platform(s); telemetry/analytics approach; controller support guarantees.

--- a/.codex/slingshot_spec.md
+++ b/.codex/slingshot_spec.md
@@ -1,0 +1,40 @@
+# Slingshot Spec (Observed)
+
+## Controls
+- **Aim**: Rotate the skull using `move_left`/`move_right` (A/D). Hold Shift (`fine_tune_left/right`) for quarter-speed rotation (`tilt_speed` 2.0 rad/s default). `move_up` (W) requests rotation reset to 0 via tween (`rotation_correction_speed` 0.2s).
+- **Charge/Power**: Fixed `jump_force` (500) in `scripts/movement/player.gd`; no charge curve. Trajectory preview only when grounded and rotation ≠ 0.
+- **Release**: `jump` action (Space) fires when grounded, applying velocity `Vector2.UP.rotated(rotation) * jump_force` and setting `is_jumping`.
+- **Braking**: Holding `move_down` (S) lerps velocity toward zero each physics frame scaled by `brake_factor` (1.0).
+
+## Physics Behavior
+- **Body**: `CharacterBody2D` with manual `move_and_collide` in `_apply_physics`.
+- **Gravity**: Adds `ProjectSettings["physics/2d/default_gravity"] * delta` each frame, minus `drag` (default linear damp). No custom gravity toggle.
+- **Velocity Dampening**: Brake lerp, plus linear damp scaling each trajectory step; no continuous air drag outside gravity term.
+- **Bounciness**: On collision, velocity bounces on normal scaled by `bounciness` (0.5). Colliding `Moveable` bodies receive impulse `-normal * push_force` (100).
+- **Floor Detection**: Ground rays in group `ground_casts` set `is_grounded`; moving platforms and TileMap linear velocities flag `on_moving_platform` and adjust `platform_velocity`.
+- **Trajectory Preview**: `scripts/gameplay/trajectory_line_rigidbody.gd` simulates up to 100 points using current direction, `jump_force`, gravity, and drag. Raycasts ahead; bounces on static colliders (half velocity). Stops early on moving platforms or moving TileMap tiles.
+
+## Camera & Feedback
+- **Camera**: Phantom Camera nodes (e.g., `GoalCam` and player-mounted) handle framing; player spawns with a `PhantomCameraNoiseEmitter2D` to pulse on impacts. No dynamic zoom tied to shot strength.
+- **Audio/FX**: Jump uses `SoundManager` with `DataManager.audio_dict["jump"]`; impacts play `"impact"` and trigger `impact_particles` plus camera noise.
+- **UI**: Trajectory line visible only while grounded and rotation non-zero; disappears on control lock or while airborne. No explicit power meter.
+
+## Fail/Reset States
+- **Death**: `death_zone.tscn` (`scripts/gameplay/death_zone.gd`) calls `Player.die()`, hiding the sprite, playing particles, emitting `EventBus.player_died` after ~2s. World respawns at current checkpoint until lives depleted.
+- **Level End**: `body_goal.tscn` (Area2D) triggers `level_end` event via `EventInteractable`, leading to dialogue and `level_end.gd` UI.
+- **Stall Cases**: No explicit unstuck timer; braking input slows the skull, and rotation reset can zero trajectory preview.
+
+## Tuning Table
+- `jump_force = 500`, `tilt_speed = 2.0`, `brake_factor = 1.0`, `rotation_correction_speed = 0.2`, `bounciness = 0.5`, `push_force = 100` (`scripts/movement/player.gd`).
+- Gravity: `ProjectSettings["physics/2d/default_gravity"]` (project default; currently inherited from engine settings).
+- Trajectory preview points: 100; bounce damp factor 0.5 (`scripts/gameplay/trajectory_line_rigidbody.gd`).
+
+## Edge Cases
+- Rotation reset sets rotation to zero, which also clears trajectory lines; launching with rotation=0 would apply pure upward force, but preview is hidden.
+- Because mid-air rotation is allowed, players can adjust facing for upcoming landings without affecting current velocity (no torque applied).
+- Bounciness plus sloped collisions can cause repeated ricochets; braking input mitigates but no cap on bounce count.
+- Moving platforms detected via TileMap linear velocity; if velocities change mid-flight there is no predictive compensation.
+
+## Known / Unknown
+- **Known:** Launch only available while grounded; mid-air control limited to rotation and braking lerp.
+- **Unknown:** Exact gravity value in Project Settings; camera follow specifics per level; whether other player variants (`player_v_1/2/3`) will replace the current controller.

--- a/.codex/tech.md
+++ b/.codex/tech.md
@@ -1,0 +1,38 @@
+# Technical Notes
+
+## Architecture Overview
+- **Autoloads** (`project.godot`): SoundManager, SceneTransitionManager, DataManager, SaveManager, GameManager, CameraShakeManager, EventBus, DialogueManager, PhantomCameraManager.
+- **World Controller**: `scripts/gameplay/world.gd` manages player spawn, HUD wiring, intro/end dialogue, and checkpoint tracking. Mirrors `scripts/utilities/world_sidecar.gd` pattern.
+- **Player**: `scripts/movement/player.gd` (`CharacterBody2D`) instantiated via `world.gd` from `scenes/common/player.tscn`.
+- **UI**: HUD and timers in `scenes/common/ui/player_hud.tscn`; level end flow in `scenes/common/ui/level_end.tscn` (`level_end.gd`). Menus managed by `scripts/ui/main_menui_control.gd`.
+- **Dialogue**: DialogueManager plugin with balloon scene `dialogue/balloons/dialogue_panel.tscn` triggered in world intro/end.
+
+## Scene Organization Rules
+- World scenes host Level nodes (`scripts/gameplay/level.gd`) that encapsulate TileMaps and camera triggers.
+- Obstacles/hazards live under `scenes/common/world_obstacles/`; interactables under `scenes/common/world_interactables/`.
+- Cameras use Phantom Camera scenes (`goal_cam.tscn`, `level_camera_2d.tscn`) with triggers (`2d_camera_trigger.gd`).
+
+## State Management
+- Lives/coins/timers tracked in GameManager/current_sidecar; events via EventBus (player_died, checkpoint_reached, level_end, etc.).
+- Level progression keyed by `DataManager.world_dict` and scene transitions handled by SceneTransitionManager.
+
+## Physics Approach
+- Player uses manual `move_and_collide` to manage bounce behavior. Gravity pulled from project settings; bouncing scaled via export vars.
+- Moving platforms detected by raycasts into TileMap or AnimatableBody2D.
+- Trajectory preview simulates same forces with raycasts to predict contact/bounce.
+
+## Save/Config
+- SaveManager autoload exists but flow not wired in world/menus yet (needs verification). Settings resource at `game_resources/settings/default.tres` referenced by menu.
+
+## Performance Considerations
+- Keep TileMaps chunked per level; limit particle counts. Phantom Camera noise should be optional to reduce shake cost.
+- Avoid excessive trajectory points; currently capped at 100.
+
+## Testing Strategy
+- Manual playtests per level for launch feel, bounce consistency, and camera framing.
+- Smoke tests: boot main menu, start world_1, hit checkpoint, die and respawn, reach body goal and continue.
+- Future: minimal unit tests for trajectory math and collision responses if adopting GUT.
+
+## Known / Unknown
+- **Known:** Exports configured for Web and Windows; Linux preset lacks path.
+- **Unknown:** SaveManager integration state; controller input mappings; whether lives/coins persist between worlds. Add checks before release.

--- a/.codex/todo.md
+++ b/.codex/todo.md
@@ -1,0 +1,73 @@
+# Backlog
+
+## High Priority Items
+- EPIC-001: Ship slingshot-first vertical slice (world_1) with reliable arc feel and level completion loop.
+
+- FEAT-001: Slingshot feel polish
+  - Priority: P0 | Effort: M | Risk: Med
+  - Acceptance: Aiming rotation, trajectory preview, and applied launch arc match within small error; bounce behaves consistently on slopes; braking stops motion reliably.
+  - Touchpoints: `scripts/movement/player.gd`, `scripts/gameplay/trajectory_line_rigidbody.gd`, `project.godot` (input/physics), level TileMaps.
+  - Dependencies: None.
+
+- FEAT-002: Fast retry & checkpoints
+  - Priority: P0 | Effort: M | Risk: Med
+  - Acceptance: Death resets within 2s to last checkpoint; add explicit restart button in HUD/pause; no soft-lock pits without death volume.
+  - Touchpoints: `scripts/gameplay/world.gd`, `scenes/common/ui/player_hud.tscn`, `scenes/common/world_obstacles/death_zone.tscn`, checkpoints.
+  - Dependencies: FEAT-001 for stable physics.
+
+- FEAT-003: Level-end body reveal loop
+  - Priority: P0 | Effort: S | Risk: Low
+  - Acceptance: Reaching `body_goal.tscn` triggers dialogue (`not_my_body.dialogue`) and shows `level_end.tscn` with Continue to next world/level.
+  - Touchpoints: `scenes/common/world_obstacles/body_goal.tscn`, `scripts/gameplay/world.gd`, `scenes/common/ui/level_end.gd`, dialogue resources.
+  - Dependencies: FEAT-002 (checkpoint/death flow) to avoid conflicts.
+
+- FEAT-004: Camera framing & readability
+  - Priority: P1 | Effort: M | Risk: Med
+  - Acceptance: Camera keeps launch origin and target in view; reduce shake intensity toggle; ensure trajectory line not obscured. Validate on world_1 levels.
+  - Touchpoints: `scenes/common/camera/*`, Phantom Camera settings, level camera triggers.
+  - Dependencies: FEAT-001.
+
+- FEAT-005: Accessibility & settings basics
+  - Priority: P1 | Effort: M | Risk: Low
+  - Acceptance: Audio volume toggle/sliders wired to SoundManager; optional screen shake toggle; document keybindings; placeholder for controller support.
+  - Touchpoints: `scripts/ui/settings_control.gd`, `game_resources/settings/default.tres`, camera noise emitters.
+  - Dependencies: FEAT-004 (shake control) optional.
+
+- FEAT-006: Export readiness
+  - Priority: P1 | Effort: S | Risk: Med
+  - Acceptance: Web and Windows exports build without missing assets; Linux preset path set; version info updated.
+  - Touchpoints: `export_presets.cfg`, `project.godot`, build pipeline docs.
+  - Dependencies: Stabilized features.
+
+## Supporting Tasks
+- TASK-001: Verify gravity value and align trajectory preview with runtime gravity.
+  - Priority: P0 | Effort: S | Risk: Med
+  - Acceptance: Document actual gravity in `slingshot_spec.md`; adjust preview math if needed.
+  - Dependencies: FEAT-001.
+
+- TASK-002: Audit SaveManager wiring
+  - Priority: P1 | Effort: S | Risk: Med
+  - Acceptance: Determine whether saves/settings persist; document or disable nonfunctional UI elements.
+  - Dependencies: None.
+
+- TASK-003: Level content review
+  - Priority: P1 | Effort: M | Risk: Med
+  - Acceptance: List hazards/checkpoints/body goal placement per level; ensure no blind hazards; update `design.md` with findings.
+  - Dependencies: FEAT-004.
+
+- TASK-004: Soft-lock prevention
+  - Priority: P0 | Effort: M | Risk: Med
+  - Acceptance: Add fail volumes or unstuck timer where bounce traps exist; braking should allow recovery. Document locations fixed.
+  - Dependencies: FEAT-002.
+
+## Bugs / Issues
+- BUG-001: Rotation reset tied to `move_up` instead of dedicated `reset_rotation` action
+  - Priority: P1 | Effort: S | Risk: Low
+  - Acceptance: Update input mapping and UI hints; ensure trajectory preview handles reset cleanly.
+  - Touchpoints: `scripts/movement/player.gd`, `project.godot` input map.
+
+## Chores
+- CHORE-001: Update documentation after each feature change (journal/todo/specs).
+  - Priority: P1 | Effort: S | Risk: Low
+  - Acceptance: `.codex/` files reflect latest implementation and decisions.
+


### PR DESCRIPTION
## Summary
- create .codex project memory with map, PRD, design, tech, release plan, backlog, and known issues
- document observed slingshot mechanic and tuning values
- seed development journal with current findings

## Testing
- not run (documentation-only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69599616819c8328830846d9f190f493)