### PR TITLE
Manage per-interactor interaction callbacks

### DIFF
--- a/scripts/interaction/interactible.gd
+++ b/scripts/interaction/interactible.gd
@@ -2,20 +2,27 @@ class_name Interactable extends Area2D
 
 signal on_interacted(interactor : Interactor)
 
+var _interact_callables : Dictionary = {}
+
 func _ready():
-	area_entered.connect(_on_area_entered)
-	area_exited.connect(_on_area_exited)
-	
+    area_entered.connect(_on_area_entered)
+    area_exited.connect(_on_area_exited)
+
 func _on_area_entered(area : Area2D):
-	if area is Interactor:
-		area.indicator.show()
-		area.on_interact.connect(_on_interact.bind(area))
-	
+    if area is Interactor:
+        area.indicator.show()
+        assert(not _interact_callables.has(area), "Interactor already connected")
+        var callable := Callable(self, "_on_interact").bind(area)
+        _interact_callables[area] = callable
+        area.on_interact.connect(callable)
+
 func _on_area_exited(area : Area2D):
-	if area is Interactor:
-		area.indicator.hide()
-		area.on_interact.disconnect(_on_interact)
+    if area is Interactor:
+        area.indicator.hide()
+        if _interact_callables.has(area):
+            area.on_interact.disconnect(_interact_callables[area])
+            _interact_callables.erase(area)
 
 func _on_interact(interactor : Interactor):
-	interactor.indicator.hide()
-	on_interacted.emit(interactor)
+    interactor.indicator.hide()
+    on_interacted.emit(interactor)


### PR DESCRIPTION
## Summary
- track and store interaction callables per interactor when areas enter
- assert to prevent duplicate connections and avoid reusing callables
- disconnect the matching callable on area exit and clear tracking

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6959b6fc3670832899cf6a2a730c275a)